### PR TITLE
ci: add `-j2` for compilation with coqc.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: type check
           command: |
-            make
+            make -j2
       - persist_to_workspace:
           root: /tmp/cpdt
           paths:


### PR DESCRIPTION
 CI 上での coqc でのビルドを並列化
